### PR TITLE
Added getNamespaceDeclaration for template tasks and unit tests

### DIFF
--- a/grunt.js
+++ b/grunt.js
@@ -3,7 +3,7 @@ module.exports = function(grunt) {
 
   grunt.initConfig({
     lint: {
-      all: ["grunt.js", "lib/*.js"]
+      all: ["grunt.js", "lib/*.js", '<config:test.tasks>']
     },
 
     jshint: {
@@ -21,8 +21,14 @@ module.exports = function(grunt) {
         node: true,
         es5: true
       }
+    },
+    
+    // Unit tests.
+    test: {
+      tasks: ['test/*_test.js']
     }
   });
 
-  grunt.registerTask("default", "lint");
+  // By default, lint and run all tests.
+  grunt.registerTask('default', 'lint test');
 };

--- a/lib/contrib.js
+++ b/lib/contrib.js
@@ -26,6 +26,25 @@ exports.init = function(grunt) {
     return _.defaults({}, task, global_subtask, global, defaults || {});
   };
 
+  exports.getNamespaceDeclaration = function(ns) {
+    var output = [];
+    var curPath = 'this';
+    if (ns !== 'this') {
+      var nsParts = ns.split('.');
+      nsParts.forEach(function(curPart, index) {
+        if (curPart !== 'this') {
+          curPath += "["+JSON.stringify(curPart)+"]";
+          output.push(curPath + ' = ' + curPath + ' || {};');
+        }
+      });
+    }
+
+    return {
+      namespace: curPath,
+      declaration: output.join('\n')
+    };
+  };
+
   // TODO: ditch this when grunt v0.4 is released
   // Temporary helper for normalizing files object
   exports.normalizeMultiTaskFiles = function(data, target) {

--- a/package.json
+++ b/package.json
@@ -23,5 +23,11 @@
   "engines": {
     "node": ">= 0.6.0"
   },
+  "scripts": {
+    "test": "grunt test"
+  },
+  "devDependencies": {
+    "grunt": "~0.3.15"
+  },
   "main": "lib/contrib"
 }

--- a/test/lib_test.js
+++ b/test/lib_test.js
@@ -1,0 +1,62 @@
+var grunt = require('grunt');
+var helper = require('../lib/contrib.js').init(grunt);
+
+exports['less'] = {
+  main: function(test) {
+    'use strict';
+
+    var expect, result;
+
+    test.expect(10);
+
+    // Both test should result in this[JST]
+    expect = {
+      namespace: 'this["JST"]',
+      declaration: 'this["JST"] = this["JST"] || {};'
+    };
+
+    result = helper.getNamespaceDeclaration("this.JST");
+    test.equal(expect.namespace, result.namespace, 'namespace with square brackets incorrect');
+    test.equal(expect.declaration, result.declaration, 'namespace declaration with square brackets incorrect');
+
+    result = helper.getNamespaceDeclaration("JST");
+    test.equal(expect.namespace, result.namespace, 'namespace with square brackets incorrect');
+    test.equal(expect.declaration, result.declaration, 'namespace declaration with square brackets incorrect');
+
+    // Templates should be declared globally if this provided
+    expect = {
+      namespace: "this",
+      declaration: ""
+    };
+
+    result = helper.getNamespaceDeclaration("this");
+    test.equal(expect.namespace, result.namespace, 'namespace with square brackets incorrect');
+    test.equal(expect.declaration, result.declaration, 'namespace declaration with square brackets incorrect');
+
+    // Nested namespace declaration
+    expect = {
+      namespace: 'this["GUI"]["Templates"]["Main"]',
+      declaration:  'this["GUI"] = this["GUI"] || {};\n' +
+                    'this["GUI"]["Templates"] = this["GUI"]["Templates"] || {};\n' +
+                    'this["GUI"]["Templates"]["Main"] = this["GUI"]["Templates"]["Main"] || {};'
+    };
+
+    result = helper.getNamespaceDeclaration("GUI.Templates.Main");
+    test.equal(expect.namespace, result.namespace, 'namespace incorrect');
+    test.equal(expect.declaration, result.declaration, 'namespace declaration incorrect');
+
+    // Namespace that contains square brackets
+    expect = {
+      namespace: 'this["main"]["[test]"]["[test2]"]',
+      declaration: 'this["main"] = this["main"] || {};\n' +
+                   'this["main"]["[test]"] = this["main"]["[test]"] || {};\n' +
+                   'this["main"]["[test]"]["[test2]"] = this["main"]["[test]"]["[test2]"] || {};'
+    };
+
+    result = helper.getNamespaceDeclaration("main.[test].[test2]");
+    test.equal(expect.namespace, result.namespace, 'namespace with square brackets incorrect');
+    test.equal(expect.declaration, result.declaration, 'namespace declaration with square brackets incorrect');
+
+    test.done();
+  }
+};


### PR DESCRIPTION
getNamespaceDeclaration will take a namespace in dot notation and return the corresponding non-destructive declaration for the namespace, as well as the namespace in bracket notation. Namespace parts are safely escaped using JSON.stringify.

That is:

```
helpers.getNamespaceDeclaration('GUI.Templates.Main');
```

Returns:

```
{
  namespace: 'this["GUI"]["Templates"]["Main"]',
  declaration: 'this["GUI"] = this["GUI"] || {};' +
               'this["GUI"]["Templates"] = this["GUI"]["Templates"] || {};' +
               'this["GUI"]["Templates"]["Main"] = this["GUI"]["Templates"]["Main"] || {};'
}
```

Special cases
- If `this` is provided, no declaration is returned and `this` is returned as the namespace.
- Providing `this.MyNamespace` produces the same output as providing `MyNamespace`.
