### PR TITLE
remove findBasePath and buildIndividualDest.

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,14 @@
+{
+  "curly": true,
+  "eqeqeq": true,
+  "immed": true,
+  "latedef": true,
+  "newcap": true,
+  "noarg": true,
+  "sub": true,
+  "undef": true,
+  "boss": true,
+  "eqnull": true,
+  "node": true,
+  "es5": true
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
 language: node_js
 node_js:
   - 0.8
+before_install:
+  - npm install -g grunt-cli

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,9 @@
-v0.4.1:
+v0.5.0:
   date: 2012-12-05
   changes:
     - remove findBasePath, buildIndividualDest and isIndividualDest.
+    - remove options and normalizeMultiTaskFiles.
+    - remove node v0.6 and grunt v0.3 support.
 v0.4.0:
   date: 2012-11-20
   changes:

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+v0.4.1:
+  date: 2012-12-05
+  changes:
+    - remove findBasePath, buildIndividualDest and isIndividualDest.
 v0.4.0:
   date: 2012-11-20
   changes:

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -9,7 +9,19 @@
 module.exports = function(grunt) {
   'use strict';
 
+  // Project configuration.
   grunt.initConfig({
+    jshint: {
+      all: [
+        'Gruntfile.js',
+        'lib/*.js',
+        '<%= nodeunit.tests %>'
+      ],
+      options: {
+        jshintrc: '.jshintrc'
+      }
+    },
+
     test_vars: {
       source: 'source/'
     },
@@ -30,33 +42,19 @@ module.exports = function(grunt) {
       }
     },
 
-    lint: {
-      all: ['grunt.js', 'lib/*.js', '<config:test.tasks>']
-    },
-
-    jshint: {
-      options: {
-        curly: true,
-        eqeqeq: true,
-        immed: true,
-        latedef: true,
-        newcap: true,
-        noarg: true,
-        sub: true,
-        undef: true,
-        boss: true,
-        eqnull: true,
-        node: true,
-        es5: true
-      }
-    },
-
     // Unit tests.
-    test: {
-      tasks: ['test/*_test.js']
+    nodeunit: {
+      tests: ['test/*_test.js']
     }
   });
 
+  // These plugins provide necessary tasks.
+  grunt.loadNpmTasks('grunt-contrib-jshint');
+  grunt.loadNpmTasks('grunt-contrib-nodeunit');
+
+  // Whenever the "test" task is run, then test the result.
+  grunt.registerTask('test', ['nodeunit']);
+
   // By default, lint and run all tests.
-  grunt.registerTask('default', 'lint test');
+  grunt.registerTask('default', ['jshint', 'test']);
 };

--- a/README.md
+++ b/README.md
@@ -14,16 +14,6 @@ _Over time, some of the functionality provided here may be incorporated directly
 
 This helper is used to build JS namespace declarations.
 
-#### normalizeMultiTaskFiles(data, target)
-
-This helper is a (temporary) shim to handle multi-task `files` object in the same way grunt v0.4 does.
-
-#### options(data, defaults)
-
-This helper is on its way out as grunt v0.4 adds an options helper to the task api. This new helper only supports task and target options (no root level options key) so you should start adjusting your tasks now to be ready for the v0.4 release.
-
-Contrib tasks are in the process of being updated to check for the new helper first.
-
 #### optsToArgs(options)
 
 Convert an object to an array of CLI arguments, which can be used with `child_process.spawn()`.

--- a/README.md
+++ b/README.md
@@ -10,21 +10,9 @@ _Over time, some of the functionality provided here may be incorporated directly
 
 ### Helper Functions
 
-#### buildIndividualDest(dest, srcFile, basePath, flatten)
-
-This helper is used to build a destination filepath for tasks supporting individual compiling.
-
-#### findBasePath(srcFiles)
-
-This helper is used to take an array of filepaths and find the common base directory.
-
 #### getNamespaceDeclaration(ns)
 
 This helper is used to build JS namespace declarations.
-
-#### isIndividualDest(dest)
-
-This helper is used to detect if a destination filepath triggers individual compiling.
 
 #### normalizeMultiTaskFiles(data, target)
 

--- a/lib/contrib.js
+++ b/lib/contrib.js
@@ -19,57 +19,6 @@ exports.init = function(grunt) {
   // TODO: remove if/when we officially drop node <= 0.7.9
   path.sep = path.sep || path.normalize('/');
 
-  exports.buildIndividualDest = function(dest, srcFile, basePath, flatten) {
-    dest = path.normalize(dest);
-    srcFile = path.normalize(srcFile);
-
-    var newDest = path.dirname(dest);
-    var newName = path.basename(srcFile, path.extname(srcFile)) + path.extname(dest);
-    var relative = path.dirname(srcFile);
-
-    if (flatten) {
-      relative = '';
-    } else if (basePath && basePath.length >= 1) {
-      relative = grunt.util._(relative).strRight(basePath).trim(path.sep);
-    }
-
-    // make paths outside grunts working dir relative
-    relative = relative.replace(/\.\.(\/|\\)/g, '');
-
-    return path.join(newDest, relative, newName);
-  };
-
-  exports.findBasePath = function(srcFiles, basePath) {
-    if (basePath === false) {
-      return '';
-    }
-
-    if (grunt.util.kindOf(basePath) === 'string' && basePath.length >= 1) {
-      return grunt.util._(path.normalize(basePath)).trim(path.sep);
-    }
-
-    var foundPath;
-    var basePaths = [];
-    var dirName;
-
-    srcFiles.forEach(function(srcFile) {
-      srcFile = path.normalize(srcFile);
-      dirName = path.dirname(srcFile);
-
-      basePaths.push(dirName.split(path.sep));
-    });
-
-    basePaths = grunt.util._.intersection.apply([], basePaths);
-
-    foundPath = path.join.apply(path, basePaths);
-
-    if (foundPath === '.') {
-      foundPath = '';
-    }
-
-    return foundPath;
-  };
-
   exports.getNamespaceDeclaration = function(ns) {
     var output = [];
     var curPath = 'this';
@@ -87,14 +36,6 @@ exports.init = function(grunt) {
       namespace: curPath,
       declaration: output.join('\n')
     };
-  };
-
-  exports.isIndividualDest = function(dest) {
-    if (grunt.util._.startsWith(path.basename(dest), '*')) {
-      return true;
-    } else {
-      return false;
-    }
   };
 
   // TODO: ditch this when grunt v0.4 is released

--- a/lib/contrib.js
+++ b/lib/contrib.js
@@ -11,13 +11,7 @@ exports.init = function(grunt) {
 
   var exports = {};
 
-  // TODO: ditch this when grunt v0.4 is released
-  grunt.util = grunt.util || grunt.utils;
-
   var path = require('path');
-
-  // TODO: remove if/when we officially drop node <= 0.7.9
-  path.sep = path.sep || path.normalize('/');
 
   exports.getNamespaceDeclaration = function(ns) {
     var output = [];
@@ -36,76 +30,6 @@ exports.init = function(grunt) {
       namespace: curPath,
       declaration: output.join('\n')
     };
-  };
-
-  // TODO: ditch this when grunt v0.4 is released
-  // Temporary helper for normalizing files object
-  exports.normalizeMultiTaskFiles = function(data, target) {
-    var prop, obj;
-    var files = [];
-    if (grunt.util.kindOf(data) === 'object') {
-      if ('src' in data || 'dest' in data) {
-        obj = {};
-        if ('src' in data) { obj.src = data.src; }
-        if ('dest' in data) { obj.dest = data.dest; }
-        files.push(obj);
-      } else if (grunt.util.kindOf(data.files) === 'object') {
-        for (prop in data.files) {
-          files.push({src: data.files[prop], dest: prop});
-        }
-      } else if (Array.isArray(data.files)) {
-        data.files.forEach(function(obj) {
-          var prop;
-          if ('src' in obj || 'dest' in obj) {
-            files.push(obj);
-          } else {
-            for (prop in obj) {
-              files.push({src: obj[prop], dest: prop});
-            }
-          }
-        });
-      }
-    } else {
-      files.push({src: data, dest: target});
-    }
-
-    // Process each normalized file object as a template.
-    files.forEach(function(obj) {
-      // Process src as a template (recursively, if necessary).
-      if ('src' in obj) {
-        obj.src = grunt.util.recurse(obj.src, function(src) {
-          if (typeof src !== 'string') { return src; }
-          return grunt.template.process(src);
-        });
-      }
-      if ('dest' in obj) {
-        // Process dest as a template.
-        obj.dest = grunt.template.process(obj.dest);
-      }
-    });
-
-    return files;
-  };
-
-  // Helper for consistent options key access across contrib tasks.
-  exports.options = function(data, defaults) {
-    var global_target = data.target ? grunt.config(['options', data.name, data.target]) : null;
-    var global_task = grunt.config(['options', data.name]);
-
-    if (global_task || global_target) {
-      grunt.fail.warn('root level [options] key will be unsupported in grunt v0.4. please consider using task and target options.');
-    }
-
-    var target = data.target ? grunt.config([data.name, data.target, 'options']) : null;
-    var task = grunt.config([data.name, 'options']);
-
-    var options = grunt.util._.defaults({}, target, task, global_target, global_task, defaults);
-
-    return grunt.util.recurse(options, function(value) {
-      if (typeof value !== 'string') { return value; }
-
-      return grunt.template.process(value);
-    });
   };
 
   // Convert an object to an array of CLI arguments

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-lib-contrib",
   "description": "Common functionality shared across grunt-contrib tasks.",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "homepage": "http://github.com/gruntjs/grunt-lib-contrib",
   "author": {
     "name": "Grunt Team",
@@ -21,13 +21,16 @@
     }
   ],
   "engines": {
-    "node": ">= 0.6.0"
+    "node": ">= 0.8.0"
   },
   "scripts": {
     "test": "grunt test"
   },
   "devDependencies": {
-    "grunt": "~0.3.15"
+    "grunt-contrib-jshint": "~0.1.0",
+    "grunt-contrib-nodeunit": "~0.1.0",
+    "grunt": "~0.4.0",
+    "grunt-cli": "~0.1.1"
   },
   "main": "lib/contrib"
 }

--- a/test/lib_test.js
+++ b/test/lib_test.js
@@ -2,26 +2,6 @@ var grunt = require('grunt');
 var helper = require('../lib/contrib.js').init(grunt);
 
 exports.lib = {
-  findBasePath: function(test) {
-    'use strict';
-    var path = require('path');
-
-    test.expect(3);
-
-    var actual = helper.findBasePath(['dir1/dir2/dir3/file.ext', 'dir1/dir2/another.ext', 'dir1/dir2/dir3/dir4/file.ext']);
-    var expected = path.normalize('dir1/dir2');
-    test.equal(expected, actual, 'should detect basePath from array of filepaths.');
-
-    actual = helper.findBasePath(['dir1/dir2/dir3/file.ext', 'dir1/dir2/another.ext', 'file.ext'], 'dir1');
-    expected = 'dir1';
-    test.equal(expected, actual, 'should default to passed basePath if valid');
-
-    actual = helper.findBasePath(['.dir1/dir2', '.dir1/dir2/another.ext', '.dir1/dir2/dir3/dir4/file.ext', 'file.ext']);
-    expected = '';
-    test.equal(expected, actual, 'should return empty string if foundPath is a single dot (helps with dotfiles)');
-
-    test.done();
-  },
   getNamespaceDeclaration: function(test) {
     'use strict';
 

--- a/test/lib_test.js
+++ b/test/lib_test.js
@@ -57,35 +57,6 @@ exports.lib = {
 
     test.done();
   },
-  options: function(test) {
-    'use strict';
-
-    test.expect(5);
-
-    var options = helper.options({name: 'test_task', target: 'target'}, {required: 'default'});
-
-    var actual = options.param;
-    var expected = 'target';
-    test.equal(expected, actual, 'should allow target options key to override task');
-
-    actual = options.param2;
-    expected = 'task';
-    test.equal(expected, actual, 'should set default task options that can be overriden by target options');
-
-    actual = options.required;
-    expected = 'default';
-    test.equal(expected, actual, 'should allow task to define default values');
-
-    actual = options.template;
-    expected = 'source/';
-    test.equal(expected, actual, 'should automatically process template vars');
-
-    actual = options.data.template;
-    expected = 'source/';
-    test.equal(expected, actual, 'should process template vars recursively');
-
-    test.done();
-  },
   optsToArgs: function(test) {
     'use strict';
 


### PR DESCRIPTION
basePath is no longer used in v0.4 tasks and a helper should be used to support dynamic 1:1 compiling vs special rules.
