### PR TITLE
Because of noticeable performance issue made gzip optional, default disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,21 +33,31 @@ Convert an object to an array of CLI arguments, which can be used with `child_pr
 
 Strip a path from a path. normalize both paths for best results.
 
-#### minMaxInfo(min, max)
+#### minMaxInfo(min, max, report)
 
 Helper for logging compressed, uncompressed and gzipped sizes of strings.
+
+#### report
+Choices: `false`, `min`, `gzip`
+Default: `false`
+
+Either do not report anything, report only minification result, or report minification and gzip results.
+
+**Important** Including `gzip` results can make this task 5-10x slower depending on the size of the file.
+
 
 ```js
 var max = grunt.file.read('max.js');
 var min = minify(max);
-minMaxInfo(min, max);
+minMaxInfo(min, max, 'min', 'gzip');
 ```
 
 Would print:
 
 ```
-Uncompressed size: 495 bytes.
-Compressed size: 36 bytes gzipped (396 bytes minified).
+Original: 495 bytes.
+Minified: 396 bytes.
+Gzipped: 36 bytes.
 ```
 
 --

--- a/README.md
+++ b/README.md
@@ -38,18 +38,18 @@ Strip a path from a path. normalize both paths for best results.
 Helper for logging compressed, uncompressed and gzipped sizes of strings.
 
 #### report
-Choices: `false`, `min`, `gzip`
+Choices: `false`, `'min'`, `'gzip'`
 Default: `false`
 
 Either do not report anything, report only minification result, or report minification and gzip results.
 
-**Important** Including `gzip` results can make this task 5-10x slower depending on the size of the file.
+**Important** Including `'gzip'` results can make this task 5-10x slower depending on the size of the file.
 
 
 ```js
 var max = grunt.file.read('max.js');
 var min = minify(max);
-minMaxInfo(min, max, 'min', 'gzip');
+minMaxInfo(min, max, 'gzip');
 ```
 
 Would print:

--- a/lib/contrib.js
+++ b/lib/contrib.js
@@ -78,13 +78,19 @@ exports.init = function(grunt) {
   };
 
   // Log min and max info
-  function minMaxGzip(src) {
-    return src ? require('zlib-browserify').gzipSync(src) : '';
+  function gzipSize(src) {
+    return src ? require('zlib-browserify').gzipSync(src).length : 0;
   }
-  exports.minMaxInfo = function(min, max) {
-    var gzipSize = String(minMaxGzip(min).length);
-    grunt.log.writeln('Uncompressed size: ' + String(max.length).green + ' bytes.');
-    grunt.log.writeln('Compressed size: ' + gzipSize.green + ' bytes gzipped (' + String(min.length).green + ' bytes minified).');
+  exports.minMaxInfo = function(min, max, report) {
+    if (report === 'min' || report === 'gzip') {
+      grunt.log.writeln('Original: ' + String(max.length).green + ' bytes.');
+      grunt.log.writeln('Minified: ' + String(min.length).green + ' bytes.');
+    }
+    if (report === 'gzip') {
+      // Note this option is pretty slow so it is not enabled by default
+      grunt.log.write('Gzipped:  ');
+      grunt.log.writeln(String(gzipSize(min)).green + ' bytes.');
+    }
   };
 
   return exports;


### PR DESCRIPTION
Changed minmax api to match suggestion proposed by @Cowboy:

gruntjs/grunt-contrib-uglify/pull/35

Will be updating that PR to match this API.
