### PR TITLE
Create formatForType method for handling type formatting (support for HTML, JS, AMD, and CommonJS)

### DIFF
--- a/lib/contrib.js
+++ b/lib/contrib.js
@@ -94,6 +94,8 @@ exports.init = function(grunt) {
   };
 
   exports.formatForType = function(string, type, namespace, filename) {
+    namespace = namespace || false;
+
     if (type === 'amd') {
       string = 'return ' + string;
     } else if (type === 'commonjs' && namespace === false) {

--- a/lib/contrib.js
+++ b/lib/contrib.js
@@ -93,5 +93,19 @@ exports.init = function(grunt) {
     }
   };
 
+  exports.formatForType = function(string, type, namespace, filename) {
+    if (type === 'amd') {
+      string = 'return ' + string;
+    } else if (type === 'commonjs' && namespace === false) {
+      string = 'module.exports = ' + string;
+    }
+
+    if (type === 'js' || type === 'commonjs' && namespace !== false) {
+      return namespace+'['+JSON.stringify(filename)+'] = '+string+';';
+    } else {
+       return string;
+    }
+  };
+
   return exports;
 };

--- a/lib/contrib.js
+++ b/lib/contrib.js
@@ -96,17 +96,15 @@ exports.init = function(grunt) {
   exports.formatForType = function(string, type, namespace, filename) {
     namespace = namespace || false;
 
-    if (type === 'amd') {
+    if (type === 'amd' && namespace === false) {
       string = 'return ' + string;
     } else if (type === 'commonjs' && namespace === false) {
       string = 'module.exports = ' + string;
+    } else if (type === 'amd' && namespace !== false || type === 'commonjs' && namespace !== false || type === 'js' && namespace !== false) {
+      string = namespace+'['+JSON.stringify(filename)+'] = '+string+';';
     }
 
-    if (type === 'js' || type === 'commonjs' && namespace !== false) {
-      return namespace+'['+JSON.stringify(filename)+'] = '+string+';';
-    } else {
-       return string;
-    }
+    return string;
   };
 
   return exports;

--- a/test/lib_test.js
+++ b/test/lib_test.js
@@ -155,5 +155,79 @@ exports.lib = {
     grunt.util.hooker.unhook(grunt.log, 'writeln');
     grunt.util.hooker.unhook(grunt.log, 'write');
     test.done();
+  },
+  formatToType: {
+    amd: function(test) {
+
+      'use strict';
+
+      test.expect(2);
+
+      var string = function () { };
+
+      var actual = helper.formatForType(string, 'amd', 'JST', 'test');
+      var expected = 'JST["test"] = function () { };';
+      test.equal(expected, actual, 'should format string to amd with namespace');
+
+      actual = helper.formatForType(string, 'amd');
+      expected = "return function () { }";
+      test.equal(expected, actual, 'should format string to amd');
+
+      test.done();
+    },
+    commonjs: function(test) {
+
+      'use strict';
+
+      test.expect(2);
+
+      var string = function () { };
+
+      var actual = helper.formatForType(string, 'commonjs', 'JST', 'test');
+      var expected = 'JST["test"] = function () { };';
+      test.equal(expected, actual, 'should format string to commonjs with namespace');
+
+      actual = helper.formatForType(string, 'commonjs');
+      expected = "module.exports = function () { }";
+      test.equal(expected, actual, 'should format string to commonjs');
+
+      test.done();
+    },
+    js: function(test) {
+
+      'use strict';
+
+      test.expect(2);
+
+      var string = function () { };
+
+      var actual = helper.formatForType(string, 'js', 'JST', 'test');
+      var expected = 'JST["test"] = function () { };';
+      test.equal(expected, actual, 'should format string to js with namespace');
+
+      actual = helper.formatForType(string, 'js');
+      expected = 'function () { }';
+      test.equal(expected, actual, 'should format string to js');
+
+      test.done();
+    },
+    html: function(test) {
+
+      'use strict';
+
+      test.expect(2);
+
+      var string = function () { };
+
+      var actual = helper.formatForType(string, 'html', 'JST', 'test');
+      var expected = 'function () { }';
+      test.equal(expected, actual, 'should format string to html with namespace');
+
+      actual = helper.formatForType(string, 'html');
+      expected = 'function () { }';
+      test.equal(expected, actual, 'should format string to html');
+
+      test.done();
+    }
   }
 };


### PR DESCRIPTION
Goes with gruntjs/grunt-contrib-jade#19
